### PR TITLE
Ntp security fork

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,6 +56,9 @@ default['ntp']['server']['use_burst'] = false
 default['ntp']['server']['minpoll'] = 6
 default['ntp']['server']['maxpoll'] = 10
 
+# Set to true if using ntp < 4.2.8 or any unpatched ntp version
+default['ntp']['localhost']['noquery'] = false
+
 # overrides on a platform-by-platform basis
 case node['platform_family']
 when 'debian'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs and configures ntp as a client or server'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.7.0'
+version           '1.7.1'
 
 recipe 'ntp', 'Installs and configures ntp either as a server or client'
 

--- a/templates/default/ntp.conf.erb
+++ b/templates/default/ntp.conf.erb
@@ -68,9 +68,9 @@ disable monitor
 <% end -%>
 
 restrict default kod notrap nomodify nopeer noquery
-restrict 127.0.0.1 nomodify
+restrict 127.0.0.1 nomodify<%if node['ntp']['localhost']['noquery'] -%> noquery<% end -%>
 restrict -6 default kod notrap nomodify nopeer noquery
-restrict -6 ::1 nomodify
+restrict -6 ::1 nomodify<%if node['ntp']['localhost']['noquery'] -%> noquery<% end -%>
 
 <%# If this is a server with additional LAN restriction lines, put them here %>
 <% unless node['ntp']['restrictions'].empty? -%>


### PR DESCRIPTION
Provide a way to set the noquery option for restrict localhost lines, for working around the latest ntp security issue.

Details of the bug & mitigation is here:  http://googleprojectzero.blogspot.nl/2015/01/finding-and-exploiting-ntpd.html
